### PR TITLE
Add --force to ansible-galaxy install

### DIFF
--- a/bin/debops-update
+++ b/bin/debops-update
@@ -165,7 +165,7 @@ if [ -z "${debops_playbooks}" ] ; then
 
   pushd ${debops_install_path} > /dev/null
   mkdir -p ${DEBOPS_GALAXY_ROLES}
-  ansible-galaxy --roles-path=${DEBOPS_GALAXY_ROLES} install --role-file=${DEBOPS_GALAXY_REQUIREMENTS}
+  ansible-galaxy --force --roles-path=${DEBOPS_GALAXY_ROLES} install --role-file=${DEBOPS_GALAXY_REQUIREMENTS}
   popd > /dev/null
 
 else


### PR DESCRIPTION
This is needed to avoid problems with ansible-galaxy and multiple
dependencies on Ansible v1.7.
