### PR TITLE
Makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,10 @@ clean-playbook:
 	@echo "Cleaning up DebOps playbook ..."
 	@rm -rf ${SHARE_DIR}
 
+# Aliases
+uninstall: uninstall-scripts uninstall-playbook
+
+uninstall-scripts: clean-scripts
+
+uninstall-playbook: clean-playbook
+

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Part of the DebOps project - http://debops.org/
 
 
-PREFIX="/usr/local"
+PREFIX?="/usr/local"
 BIN_DIR="${PREFIX}/bin"
 SHARE_DIR="${PREFIX}/share/debops"
 


### PR DESCRIPTION
Following #59 here are two changes for the Makefile.

The change regarding PREFIX will create a dependency on GNU make or similar implementations, so YMMV.

I made the aliases since from my previous experiences the 'clean' target has always been connected to cleaning up the build directory after configuration/compilation, etc. and the uninstall gives a nice diametric incantation to the install target. (Since as a newcomer I do not know where the Makefile is used in the big picture apart from simple user installation I did not want to rename the targets but please do so instead if it makes sense...)
