### PR TITLE
Revert "Honour PREFIX environment variable if set. Requires GNU make."

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Part of the DebOps project - http://debops.org/
 
 
-PREFIX?="/usr/local"
+PREFIX="/usr/local"
 BIN_DIR="${PREFIX}/bin"
 SHARE_DIR="${PREFIX}/share/debops"
 


### PR DESCRIPTION
Better fix the documentation to show the correct usage.
This reverts commit 353587d1fab9fc67e0ff694d33f3d5d389c3ec91.

See #59 
