### PR TITLE
Enhance padlock: sub-commands `init`, `lock` and `unlock` for `debops-padlock`.

### DIFF
--- a/bin/debops-padlock
+++ b/bin/debops-padlock
@@ -153,7 +153,8 @@ def unlock(encfs_decrypted, encfs_encrypted, **kwargs):
 
 
 parser = argparse.ArgumentParser()
-subparsers = parser.add_subparsers(help='action to perform. Use `%(prog)s --help <action>` for further help.')
+subparsers = parser.add_subparsers(
+    help='action to perform. Use `%(prog)s --help <action>` for further help.')
 
 p = subparsers.add_parser('init')
 p.add_argument('recipients', nargs='*',

--- a/bin/debops-padlock
+++ b/bin/debops-padlock
@@ -61,7 +61,7 @@ SCRIPT_FILENAME = 'padlock-script'
 
 # ---- DebOps environment setup ----
 
-def main(recipients):
+def main(subcommand_func, **kwargs):
     debops_root = find_debops_project(required=True)
     # :todo: Source DebOps configuration file
     #[ -r ${debops_config} ] && source ${debops_config}
@@ -82,7 +82,10 @@ def main(recipients):
                                    ENCFS_PREFIX + SECRET_NAME)
     encfs_decrypted = os.path.join(os.path.dirname(inventory_path),
                                    SECRET_NAME)
+    subcommand_func(encfs_decrypted, encfs_encrypted, **kwargs)
 
+
+def init(encfs_decrypted, encfs_encrypted, recipients):
     # EncFS cannot create encrypted directory if directory with
     # decrypted data is not empty
     if not os.path.exists(encfs_decrypted):
@@ -143,12 +146,16 @@ def main(recipients):
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('recipients', nargs='*',
-                    help=("GPG recipients for which the secret key should be "
-                          "encrypted for (name, e-mail or key-id)"))
+subparsers = parser.add_subparsers(help='action to perform. Use `%(prog)s --help <action>` for further help.')
+p = subparsers.add_parser('init')
+p.add_argument('recipients', nargs='*',
+               help=("GPG recipients for which the secret key should be "
+                     "encrypted for (name, e-mail or key-id)"))
+p.set_defaults(subcommand_func=init)
+
 args = parser.parse_args()
 
 try:
-    main(args.recipients)
+    main(**vars(args))
 except KeyboardInterrupt:
     raise SystemExit('... aborted')

--- a/bin/debops-padlock
+++ b/bin/debops-padlock
@@ -145,11 +145,20 @@ def init(encfs_decrypted, encfs_encrypted, recipients):
     os.remove(encfs_configfile)
 
 
-def lock(encfs_decrypted, encfs_encrypted, **kwargs):
-    padlock_lock(encfs_encrypted)
+def lock(encfs_decrypted, encfs_encrypted, verbose):
+    # Unmount the directory if it is mounted
+    if padlock_lock(encfs_encrypted):
+        if verbose: print("Locked!")
+    else:
+        if verbose: print("Is already locked.")
 
-def unlock(encfs_decrypted, encfs_encrypted, **kwargs):
-    padlock_unlock(encfs_encrypted)
+
+def unlock(encfs_decrypted, encfs_encrypted, verbose):
+    # Mount the directory it if it is unmounted
+    if padlock_unlock(encfs_encrypted):
+        if verbose: print("Unlocked!")
+    else:
+        if verbose: print("Is already unlocked.")
 
 
 parser = argparse.ArgumentParser()
@@ -163,9 +172,11 @@ p.add_argument('recipients', nargs='*',
 p.set_defaults(subcommand_func=init)
 
 p = subparsers.add_parser('unlock')
+p.add_argument('-v', '--verbose', action='store_true', help="be verbose")
 p.set_defaults(subcommand_func=unlock)
 
 p = subparsers.add_parser('lock')
+p.add_argument('-v', '--verbose', action='store_true', help="be verbose")
 p.set_defaults(subcommand_func=lock)
 
 args = parser.parse_args()

--- a/bin/debops-padlock
+++ b/bin/debops-padlock
@@ -145,13 +145,27 @@ def init(encfs_decrypted, encfs_encrypted, recipients):
     os.remove(encfs_configfile)
 
 
+def lock(encfs_decrypted, encfs_encrypted, **kwargs):
+    padlock_lock(encfs_encrypted)
+
+def unlock(encfs_decrypted, encfs_encrypted, **kwargs):
+    padlock_unlock(encfs_encrypted)
+
+
 parser = argparse.ArgumentParser()
 subparsers = parser.add_subparsers(help='action to perform. Use `%(prog)s --help <action>` for further help.')
+
 p = subparsers.add_parser('init')
 p.add_argument('recipients', nargs='*',
                help=("GPG recipients for which the secret key should be "
                      "encrypted for (name, e-mail or key-id)"))
 p.set_defaults(subcommand_func=init)
+
+p = subparsers.add_parser('unlock')
+p.set_defaults(subcommand_func=unlock)
+
+p = subparsers.add_parser('lock')
+p.set_defaults(subcommand_func=lock)
 
 args = parser.parse_args()
 

--- a/lib/debops/padlock-script
+++ b/lib/debops/padlock-script
@@ -1,11 +1,8 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-"""
-padlock: lock/unlock EncFS-encrypted directory with GPG key/passphrase
-"""
+#!/bin/sh
+#
 # Copyright (C) 2014 Hartmut Goebel <h.goebel@crazy-compilers.com>
 # Part of the DebOps project - http://debops.org/
-
+#
 # This program is free software; you can redistribute
 # it and/or modify it under the terms of the
 # GNU General Public License as published by the Free
@@ -27,41 +24,9 @@ padlock: lock/unlock EncFS-encrypted directory with GPG key/passphrase
 # be downloaded from the FSF web page at:
 # http://www.gnu.org/copyleft/gpl.html
 
-import os
-import argparse
-
-from debops import *
-from debops.cmds import *
-
-__author__ = "Hartmut Goebel <h.goebel@crazy-compilers.com>"
-__copyright__ = "Copyright 2014 by Hartmut Goebel <h.goebel@crazy-compilers.com>"
-__licence__ = "GNU General Public License version 3 (GPL v3) or later"
-
-
-def main(action):
-    require_commands('encfs', 'fusermount', 'gpg')
-
-    # Get the absolute path to script's directory
-    encfs_encrypted = os.path.dirname(os.path.realpath(__file__))
-
-    if action == 'lock':
-        # Unmount the directory if mounted ...
-        if padlock_lock(encfs_encrypted):
-            print("Locked!")
-        else:
-            print("Is already locked.")
-    elif action == 'unlock':
-        # ... or mount it if unmounted
-        if padlock_unlock(encfs_encrypted):
-            print("Unlocked!")
-        else:
-            print("Is already unlocked.")
-
-parser = argparse.ArgumentParser()
-parser.add_argument('action', choices=['lock', 'unlock'])
-args = parser.parse_args()
-
-try:
-    main(args.action)
-except KeyboardInterrupt:
-    raise SystemExit('... aborted')
+if [ -z "$(which debops-padlock 2>/dev/null)" ] ; then
+    echo "Command 'debops-padlock' is missing, please install debops."
+    echo "See http://www.debops.org/ for more information."
+    exit 10
+fi
+debops-padlock "$@"


### PR DESCRIPTION
Please note: This is an incompatible change. To get the previous behaviour, one needs to call `debops-padlock init` now.
