### PR TITLE
Fixed indentation typo

### DIFF
--- a/debops/config.py
+++ b/debops/config.py
@@ -52,7 +52,7 @@ def get_config_filenames():
                       ['/etc'])
         configdirs = [os.path.expanduser(d) for d in configdirs]
         configdirs.reverse()
-        return [os.path.join(d, 'debops.cfg') for d in configdirs]
+    return [os.path.join(d, 'debops.cfg') for d in configdirs]
 
 _configfiles = get_config_filenames()
 


### PR DESCRIPTION
Wrong indentation of return statement in get_config_filenames() caused it to only return if environment was Linux
