### PR TITLE
Use `git ref-parse` for geting the commit-hashes instead of do-it-outself.

### DIFF
--- a/bin/debops-update
+++ b/bin/debops-update
@@ -151,20 +151,12 @@ def update_git_repository(path):
     old_pwd = os.getcwd()
     os.chdir(path)
 
-    # Parse out the head branch name
-    with open(os.path.join('.git', 'HEAD')) as fh:
-        head_branch_path = fh.readline().strip().split(None, 1)[1]
-        head_branch = head_branch_path.rsplit('/', 1)[-1]
-
-    # Get the current sha
-    with open(os.path.join('.git', head_branch_path)) as fh:
-        current_sha = fh.readline().strip().split(None, 1)[0]
+    # Get the current sha of the head branch
+    current_sha = subprocess.check_output(['git', 'rev-parse', 'HEAD']).strip()
 
     # Fetch it silently and store the new sha
     subprocess.call(['git', 'fetch', '--quiet'])
-
-    with open(os.path.join('.git', 'FETCH_HEAD')) as fh:
-        fetch_sha = fh.readline().split(None, 1)[0]
+    fetch_sha = subprocess.check_output(['git', 'rev-parse', 'FETCH_HEAD']).strip()
 
     if current_sha != fetch_sha:
         subprocess.call(['git', 'merge', fetch_sha])


### PR DESCRIPTION
This leaves the dirty work for handling corner-cases to git.

This solves this issue:
After running `git gc --aggressive` on there is no file `.git/refs/head/master`, so debops-update crashes. This command removes `.git/refs/head/master` and refs would have to be looked up in `.gi/packed-refs`.

When trying to solve this, I first found the commend `git show-ref` resp. `git show-ref --heads`. But this still does not give use the HEAD branch. But `git rev-parse HEAD` directly gives us the current sha of the head branch – letting git do the whole dirty work.

As a plus, this is future proof and we do not need to care about file format changes 
