### PR TITLE
Do not eat return code for breakfast!

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ v0.4.3
 
 - Rearranged documentation. [drybjed]
 
+- Properly propagate exit code when running debops [do3cc]
+
 v0.4.2
 ------
 

--- a/bin/debops
+++ b/bin/debops
@@ -163,13 +163,13 @@ def main(cmd_args):
         # Run ansible-playbook with custom environment
         print("Running Ansible playbook from:")
         print(play, "...")
-        subprocess.call(['ansible-playbook', play] + cmd_args)
+        return subprocess.call(['ansible-playbook', play] + cmd_args)
     finally:
         if revert_unlock:
             padlock_lock(encfs_encrypted)
 
 
 try:
-    main(sys.argv[1:])
+    sys.exit(main(sys.argv[1:]))
 except KeyboardInterrupt:
     raise SystemExit('... aborted')


### PR DESCRIPTION
subprocess.call returns an exit code that, must be handled properly!
In success, main returns 0 and sys.exit(0) in 173 also means success
