### PR TITLE
bootstrap-ansible: Use https:// URL instead of git://

### DIFF
--- a/misc/scripts/bootstrap-ansible.sh
+++ b/misc/scripts/bootstrap-ansible.sh
@@ -34,7 +34,7 @@
 set -e
 
 # Ansible project repository to use
-project="git://github.com/ansible/ansible.git"
+project="https://github.com/ansible/ansible.git"
 
 # Select branch to build
 branch="${1:-devel}"


### PR DESCRIPTION
This make it a little easier for people behind a proxy, because setting
up git s.t. it uses a proxy for the git protocol is much harder than
making it use an HTTP proxy.
