### PR TITLE
Comments and sentences should in general end with a period.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -90,7 +90,7 @@ For everything:
 
 - Try your best to stay under 80 characters but don't go crazy trying
 - 2 space indentation for everything unless noted otherwise
-- Comments and output start with a capital letter and have no periods
+- Comments and output start with a capital letter and end with a period
 
 For just yaml:
 


### PR DESCRIPTION
This is already done in new roles:
https://github.com/debops/ansible-docker/blob/b2c9fe182db376ab050196a72fb6b21d12285be2/defaults/main.yml#L16

Older roles will have to be updated over time.
