### PR TITLE
Fixed debops-defaults writing junk when piping into Vim.

### DIFF
--- a/bin/debops-defaults
+++ b/bin/debops-defaults
@@ -52,7 +52,8 @@ def cat(filename, outstream):
         outstream.write('%s: %s\n' % (e.strerror, e.filename))
         return
     try:
-        outstream.writelines(fh)
+        # Read input file as Unicode object and pass it to outstream.
+        outstream.write(fh.read())
     finally:
         fh.close()
 


### PR DESCRIPTION
I admit that I don’t totally understand it but it works now on Debian Jessie.
