### PR TITLE
Fixed Unicode support for debops-defaults.

### DIFF
--- a/bin/debops-defaults
+++ b/bin/debops-defaults
@@ -37,6 +37,9 @@ import glob
 import argparse
 import errno
 
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
 from debops import *
 from debops.cmds import *
 


### PR DESCRIPTION
- http://stackoverflow.com/a/14919377/2239985
- Solution might not be the best but it works and switching to Python 3
  would solve this anyway so I propose this hack.
- Related to https://github.com/nickjj/ansigenome/pull/22
- Closes https://github.com/debops/ansible-dnsmasq/pull/20
