### PR TITLE
Restore ansible.cfg generation (Fixes #142)

### DIFF
--- a/bin/debops
+++ b/bin/debops
@@ -146,8 +146,8 @@ def main(cmd_args):
 
     ansible_config_file = os.path.join(project_root, ANSIBLE_CONFIG_FILE)
     os.environ['ANSIBLE_CONFIG'] = os.path.abspath(ansible_config_file)
-    #  gen_ansible_cfg(ansible_config_file, config, project_root, playbooks_path,
-    #                  inventory_path)
+    gen_ansible_cfg(ansible_config_file, config, project_root, playbooks_path,
+                    inventory_path)
 
     # Allow insecure SSH connections if requested
     if INSECURE:


### PR DESCRIPTION
In bin/debops, the call to function gen_ansible_cfg was accidentally
commented out in #134. This restores the call.
