### PR TITLE
Fix debops-task example.

### DIFF
--- a/docs/scripts/debops-task.rst
+++ b/docs/scripts/debops-task.rst
@@ -14,5 +14,5 @@ Example commands:
 
     debops-task all -m setup
 
-    debops-task somegroup -m shell "touch /tmp/foo && rm -rf /tmp/foo"
+    debops-task somegroup -m shell -a "touch /tmp/foo && rm -rf /tmp/foo"
 


### PR DESCRIPTION
debops-task requires the "-a" switch when given arguments to a module.
