### PR TITLE
Run git fetch before diffing the remote repository.

### DIFF
--- a/bin/debops-update
+++ b/bin/debops-update
@@ -142,6 +142,7 @@ def update_git_repository(path, dry_run=False):
     os.chdir(path)
 
     if dry_run:
+        subprocess.call(['git', 'fetch'])
         subprocess.call(['git', 'diff', 'HEAD', 'origin', '--stat'])
     else:
         # Get the current sha of the head branch


### PR DESCRIPTION
For debops-update --dry-run to work properly, the remote needs to be
fetched beforehand.